### PR TITLE
[Feature] Implement Batch Gradient Descent

### DIFF
--- a/NeuralNetworkCSharp.UnitTest/NetworkTest.cs
+++ b/NeuralNetworkCSharp.UnitTest/NetworkTest.cs
@@ -1,4 +1,5 @@
 using NeuralNetworkCSharp.Core;
+using NeuralNetworkCSharp.Domain;
 using NeuralNetworkCSharp.Enum;
 
 namespace NeuralNetworkCSharp.UnitTest;
@@ -40,7 +41,7 @@ public class NetworkTest
         List<double> expected = new() { 0.9509223 };
         var tolerance= 0.00001;
         
-        var output = network.UpdateMiniBatch(inputNetwork, expected);
+        var output = network.ForwardPass(inputNetwork, out _, out _);
         Assert.All(output, (o, index) =>
         {
             var expectedResult = expected[index];
@@ -59,6 +60,7 @@ public class NetworkTest
         List<int> networkSize = new List<int>(){ inputLayer, secondLayer, outputLayer }; 
         
         Network network = new Network(networkSize);
+        double learningRate = 0.5;
         
         // Initialize the weight and bias
         List<double> weights = new List<double>() { 0.15, 0.20, 0.25, 0.30, 0.40, 0.45, 0.50, 0.55 };
@@ -80,7 +82,10 @@ public class NetworkTest
             0.35891648, 0.408666186, 0.511301270, 0.561370121
         };
         
-        var outputFeedForward = network.UpdateMiniBatch(inputNetwork, outputTrueLabels, 0.5);
+        // Get the feed forward result
+        List<List<double>> activations;
+        List<List<double>> zs;
+        var outputFeedForward = network.ForwardPass(inputNetwork, out activations, out zs);
         
         // Check if the feedforward result is correct
         Assert.All(outputFeedForward, (o, index) =>
@@ -89,6 +94,12 @@ public class NetworkTest
             Assert.InRange(o, expectedResult - tolerance, expectedResult + tolerance);
         });
         
+        // Get the result of the backpropagation and update its weight and biases
+        GradientParameters gradientParameters = 
+            network.Backpropagation(activations, zs, outputFeedForward, outputTrueLabels, learningRate);
+        network.UpdateWeights(gradientParameters.NablaWeights, 1, learningRate);
+        network.UpdateBiases(gradientParameters.NablaBiases, 1, learningRate);
+        
         // Get the weights of the network and check the result with tolerance
         List<double> actualWeights = network.ExportWeights();
         Assert.All(actualWeights, (w, index) =>
@@ -96,7 +107,7 @@ public class NetworkTest
             var expectedWeight = expectedWeights[index];
             Assert.InRange(w, expectedWeight - tolerance, expectedWeight + tolerance);
         });
-
+    
     }
     
     
@@ -111,6 +122,7 @@ public class NetworkTest
         List<int> networkSize = new List<int>(){ inputLayer, secondLayer, outputLayer }; 
         
         Network network = new Network(networkSize);
+        double learningRate = 0.5;
         
         // Initialize the weight and bias
         List<double> weights = new List<double>() { 0.15, 0.20, 0.25, 0.30, 0.40, 0.45, 0.50, 0.55 };
@@ -132,7 +144,10 @@ public class NetworkTest
             0.35891648, 0.408666186, 0.511301270, 0.561370121
         };
         
-        var outputFeedForward = network.UpdateMiniBatch(inputNetwork, outputTrueLabels, 0.5, BackpropagationMethod.MatrixMultiplication);
+        // Get the feed forward result
+        List<List<double>> activations;
+        List<List<double>> zs;
+        var outputFeedForward = network.ForwardPass(inputNetwork, out activations, out zs);
         
         // Check if the feedforward result is correct
         Assert.All(outputFeedForward, (o, index) =>
@@ -141,6 +156,12 @@ public class NetworkTest
             Assert.InRange(o, expectedResult - tolerance, expectedResult + tolerance);
         });
         
+        // Get the result of the backpropagation and update its weight and biases
+        GradientParameters gradientParameters = 
+            network.Backpropagation(activations, zs, outputFeedForward, outputTrueLabels, learningRate, BackpropagationMethod.MatrixMultiplication);
+        network.UpdateWeights(gradientParameters.NablaWeights, 1, learningRate);
+        network.UpdateBiases(gradientParameters.NablaBiases, 1, learningRate);
+        
         // Get the weights of the network and check the result with tolerance
         List<double> actualWeights = network.ExportWeights();
         Assert.All(actualWeights, (w, index) =>
@@ -148,7 +169,7 @@ public class NetworkTest
             var expectedWeight = expectedWeights[index];
             Assert.InRange(w, expectedWeight - tolerance, expectedWeight + tolerance);
         });
-
+    
     }
     
     // TODO : add unit test for loading the .wes model file and return the correct prediction

--- a/NeuralNetworkCSharp/Core/DatasetLoader.cs
+++ b/NeuralNetworkCSharp/Core/DatasetLoader.cs
@@ -54,12 +54,12 @@ public class DatasetLoader
         return labelEncoding;
     }
     
-    public List<(List<string> images, List<double[]> labels)> ShuffleDataset(List<string> images, List<double[]> labels, int batchSize = 100)
+    public List<BatchData> ShuffleDataset(List<string> images, List<double[]> labels, int batchSize = 100)
     {
         int count = images.Count;
         int batchSet = BatchSet(batchSize, count);
         (List<string> shuffledImages, List<double[]> shuffledLabels) = Shuffle(images, labels);
-        List<(List<string> images, List<double[]> labels)> batches = new();
+        List<BatchData> batches = new();
         
         int index = 0;
         for (int i = 0; i < batchSet; i++)
@@ -73,7 +73,12 @@ public class DatasetLoader
                 miniBatchLabels.Add(shuffledLabels[index]);
                 index++;
             }
-            batches.Add((miniBatchImages, miniBatchLabels));
+
+            batches.Add(new BatchData()
+            {
+                Images = miniBatchImages,
+                Labels = miniBatchLabels
+            });
         }
         return batches;
     }

--- a/NeuralNetworkCSharp/Core/Network.cs
+++ b/NeuralNetworkCSharp/Core/Network.cs
@@ -74,13 +74,59 @@ public class Network : INetwork
         }
         return weights;
     }
+
+    /// <summary>
+    /// Generate initial value of nabla biases in their each layer
+    /// </summary>
+    /// <param name="x">The value you want to set on the nabla biases</param>
+    /// <returns>List of nabla biases of each neuron in their each layer</returns>
+    private List<List<double>> GenerateInitialNablaBiases(double x)
+    {
+        List<List<double>> nablaBiases = new List<List<double>>();
+        for (int i = 1; i < NumLayers; i++)
+        {
+            List<double> layerBiases = new List<double>();
+
+            for (int j = 0; j < Sizes[i]; j++)
+                layerBiases.Add(x);
+            
+            nablaBiases.Add(layerBiases);
+        }
+        return nablaBiases;
+    } 
+    
+    /// <summary>
+    /// Generate initial value of nabla weights in their each layer
+    /// </summary>
+    /// <param name="x">The value you want to set on the nabla weights</param>
+    /// <returns>List of nabla weights of each neuron in their each layer</returns>
+    private List<List<List<double>>> GenerateInitialNablaWeights(double x)
+    {
+        List<List<List<double>>> nablaWeights = new ();
+        for (int i = 1; i < NumLayers; i++)
+        {
+            List<List<double>> layerWeights = new List<List<double>>();
+
+            for (int j = 0; j < Sizes[i]; j++)
+            {
+                List<double> neuronWeights = new List<double>();
+                for (int k = 0; k < Sizes[i - 1]; k++)
+                    neuronWeights.Add(x);
+                
+                layerWeights.Add(neuronWeights);
+            }
+            nablaWeights.Add(layerWeights);
+        }
+        return nablaWeights;
+    }
     
     /// <summary>
     /// Importing Custom Weights based on the Network Layer and their individual neuron inputs
     /// Follow the scheme of index 0 start from the left, with the first input of the current L-Layer the first
     /// Follow the second index 1 of their second weight on that neuron
     /// </summary>
-    /// <param name="weights"></param>
+    /// <param name="weights">List of the weight in form of array
+    /// The total of arrays must match to the number of the network weights in all layer</param>
     /// <returns>Loading weights into network</returns>
     public void ImportWeights(List<double> weights)
     {
@@ -110,7 +156,8 @@ public class Network : INetwork
     /// <summary>
     /// Importing Custom Bias based on the Network Layer and their individual neuron inputs
     /// </summary>
-    /// <param name="biases"></param>
+    /// <param name="biases">List of the biases network in form of array
+    /// The total of arrays must match to the number of the network biases in all layer</param>
     /// <returns>Loading biases into network</returns>
     public void ImportBiases(List<double> biases)
     {
@@ -169,14 +216,82 @@ public class Network : INetwork
         }
         return exportBiases;
     }
+
+    /// <summary>
+    /// Enumerate the gradients parameter of the network from each data backpropagation result on the batch data
+    /// </summary>
+    /// <param name="batchGradientParameters">The accumulated gradients parameter value of the batch</param>
+    /// <param name="dataGradientParameters">The gradients parameter value that was got from the backpropagation result</param>
+    /// <returns>The add up value of nabla weights and nabla biases of the batch result</returns>
+    public GradientParameters AccumulatedGradients(GradientParameters batchGradientParameters, GradientParameters dataGradientParameters)
+    {
+        GradientParameters accumulatedGradientParameters = new GradientParameters()
+        {
+            NablaBiases = AccumulateNablaBiases(batchGradientParameters.NablaBiases, dataGradientParameters.NablaBiases),
+            NablaWeights = AccumulateNablaWeights(batchGradientParameters.NablaWeights, dataGradientParameters.NablaWeights)
+        };
+        return accumulatedGradientParameters;
+    }
+    
+    /// <summary>
+    /// Enumerate the biases parameter of the network from each data backpropagation result on the batch data
+    /// </summary>
+    /// <param name="batchNablaBiases">The accumulated biases parameter value of the batch</param>
+    /// <param name="nablaBiases">The biases parameter value that was got from the backpropagation result</param>
+    /// <returns>The add up value of nabla biases of the batch result</returns>
+    private List<List<double>> AccumulateNablaBiases(List<List<double>> batchNablaBiases, List<List<double>> nablaBiases)
+    {
+        if (batchNablaBiases[0].Count != nablaBiases[0].Count)
+            throw new InvalidOperationException("The dimension of nabla biases from the batch must be the same as the dimension of the nabla biases on the data");
+        
+        for (int i = 0; i < batchNablaBiases.Count; i++)
+        {
+            for (int j = 0; j < batchNablaBiases[i].Count; j++)
+            {
+                if (batchNablaBiases[i].Count != nablaBiases[i].Count)
+                    throw new InvalidOperationException($"The dimension of the intermitten layer of B-Layer[{i}][{j}] does not match the number of network biases");
+                
+                batchNablaBiases[i][j] += nablaBiases[i][j];
+            }
+        }
+        return batchNablaBiases;
+    }
+    
+    /// <summary>
+    /// Enumerate the weights parameter of the network from each data backpropagation result on the batch data
+    /// </summary>
+    /// <param name="batchNablaWeights">The accumulated weights parameter value of the batch</param>
+    /// <param name="nablaWeights">The weights parameter value that was got from the backpropagation result</param>
+    /// <returns>The add up value of nabla weights of the batch result</returns>
+    private List<List<List<double>>> AccumulateNablaWeights(List<List<List<double>>> batchNablaWeights, List<List<List<double>>> nablaWeights)
+    {
+        if (batchNablaWeights[0].Count != nablaWeights[0].Count)
+            throw new InvalidOperationException("The dimension of weights must be the same as the dimension of the nabla weights network");
+        
+        for (int i = 0; i < batchNablaWeights.Count; i++)
+        {
+            for (int j = 0; j < batchNablaWeights[i].Count; j++)
+            {
+                if (batchNablaWeights[i][j].Count != nablaWeights[i][j].Count)
+                    throw new InvalidOperationException($"The dimension of the intermitten layer of W-Layer[{i}][{j}] does not match the number of network weights");
+                
+                for (int k = 0; k < batchNablaWeights[i][j].Count; k++)
+                {
+                    batchNablaWeights[i][j][k] += nablaWeights[i][j][k];
+                }
+            }
+        }
+        return batchNablaWeights;
+    }
     
     /// <summary>
     /// Update the weights
     /// </summary>
     /// <param name="nablaWeights">Gradient of weights over the loss function</param>
-    /// <param name="learningRate"></param>
+    /// <param name="batchSize">batch size</param>
+    /// <param name="learningRate">learning rate</param>
     /// <returns>Update the weights of the network</returns>
-    private void UpdateWeights(List<List<List<double>>> nablaWeights, double learningRate)
+    public void UpdateWeights(List<List<List<double>>> nablaWeights, int batchSize, double learningRate)
     {
         if (Weights[0].Count != nablaWeights[0].Count)
             throw new InvalidOperationException("The dimension of weights must be the same as the dimension of the nabla weights network");
@@ -190,19 +305,20 @@ public class Network : INetwork
                 
                 for (int k = 0; k < Weights[i][j].Count; k++)
                 {
-                    Weights[i][j][k] += - learningRate * nablaWeights[i][j][k];
+                    Weights[i][j][k] += -(learningRate/batchSize) * nablaWeights[i][j][k];
                 }
             }
         }
     }
-    
+  
     /// <summary>
     /// Update the biases
     /// </summary>
     /// <param name="nablaBiases">Gradient of bias over the loss function</param>
-    /// <param name="learningRate"></param>
+    /// <param name="batchSize">batch size</param>
+    /// <param name="learningRate">learning rate</param>
     /// <returns>Update the biases of the network</returns>
-    private void UpdateBiases(List<List<double>> nablaBiases, double learningRate)
+    public void UpdateBiases(List<List<double>> nablaBiases, int batchSize, double learningRate)
     {
         if (Biases[0].Count != nablaBiases[0].Count)
             throw new InvalidOperationException("The dimension of biases must be the same as the dimension of the nabla biases network");
@@ -214,7 +330,7 @@ public class Network : INetwork
                 if (Biases[i].Count != nablaBiases[i].Count)
                     throw new InvalidOperationException($"The dimension of the intermitten layer of B-Layer[{i}][{j}] does not match the number of network biases");
                 
-                Biases[i][j] += -learningRate * nablaBiases[i][j];
+                Biases[i][j] += -(learningRate/batchSize) * nablaBiases[i][j];
             }
         }
     }
@@ -309,7 +425,6 @@ public class Network : INetwork
     {
         return inputs.Select(DerivativeSigmoidKernelFunction).ToList();
     }
-    
 
     /// <summary>
     /// Calculate the losses (labels - prediction) using Cross-Entropy Loss
@@ -346,26 +461,56 @@ public class Network : INetwork
     /// <summary>
     /// Network calculation learning frocm input layer to output layer in batches (with learning and backpropagation)
     /// </summary>
-    /// <param name="input">the input data</param>
-    /// <param name="outputLabels">the labels value of the data</param>
+    /// <param name="batch">the input data</param>
     /// <param name="learningRate">learning rate - the value of how much gradient descent will step</param>
     /// <param name="method">for calculating the weights and bias update, prefer to calculate it straight in each layer at the same time (Matrix Calculation) or one at-a-time in each layer in every neuron</param>
     /// <returns>Result prediction of the output layer</returns>
-    public List<double> UpdateMiniBatch(List<double> input, List<double> outputLabels,
+    public double UpdateMiniBatch(BatchData batch,
         double learningRate=0.01, BackpropagationMethod method = BackpropagationMethod.Forloop)
     {
-        if(input.Count != Sizes[0]) 
-            throw new Exception($"The number of inputs must match the number of input perceptron. Current Input perceptron {Sizes[0]}");
+        // Get the batch size
+        if (batch.Images.Count != batch.Labels.Count)
+            throw new InvalidOperationException("The number of image batches must match the number of images labels!");
+        int batchSize = batch.Images.Count;
         
-        // Run forward pass and get activations
-        List<List<double>> activations;
-        List<List<double>> zs;
-        List<double> outputActivation = ForwardPass(input, out activations, out zs);
+        // Initialize the gradient for this batch to store the accumulated gradients that should be update weight and biases
+        GradientParameters batchGradientParameter = new GradientParameters()
+        {
+            NablaBiases = GenerateInitialNablaBiases(0),
+            NablaWeights = GenerateInitialNablaWeights(0),
+        };
         
-        // Do backpropagation and update the weights and biases of the network
-        Backpropagation(activations, zs, outputActivation, outputLabels, learningRate, method);
-
-        return outputActivation;
+        // Initialize the error of the batch for reporting
+        List<double> errorMiniBatch = new();
+        
+        for (int k = 0; k < batchSize; k++)
+        {
+            double[] imageProcessing = _imageProcessing.SingleImageProcessing(batch.Images[k]);
+            List<double> imageInput = imageProcessing.ToList();
+            List<double> imageLabels = batch.Labels[k].ToList();
+            
+            if(imageInput.Count != Sizes[0]) 
+                throw new Exception($"The number of inputs must match the number of input perceptron. Current Input perceptron {Sizes[0]}");
+            
+            // Run forward pass and get activations and it's error
+            List<List<double>> activations;
+            List<List<double>> zs;
+            List<double> outputActivation = ForwardPass(imageInput, out activations, out zs);
+            double error = CalculateMeanSquareErrorLoss(outputActivation, imageLabels);
+            errorMiniBatch.Add(error);
+            
+            // Do backpropagation and get its nabla weight and biases weight and biases
+            GradientParameters gradientParametersData =  Backpropagation(activations, zs, outputActivation, imageLabels, learningRate, method);
+            
+            // Accumulate the gradients result of the weight and biases of this batch
+            batchGradientParameter = AccumulatedGradients(batchGradientParameter, gradientParametersData);
+        }
+        double averageBatchError = errorMiniBatch.Average();
+        
+        UpdateWeights(batchGradientParameter.NablaWeights, batchSize, learningRate);
+        UpdateBiases(batchGradientParameter.NablaBiases, batchSize, learningRate);
+        
+        return averageBatchError;
     }
     
     /// <summary>
@@ -427,7 +572,7 @@ public class Network : INetwork
     /// <param name="learningRate">learning rate - the value of how much gradient descent will step</param>
     /// <param name="method">for calculating the weights and bias update, prefer to calculate it straight in each layer at the same time (Matrix Calculation) or one at-a-time in each layer in every neuron</param>
     /// <returns>nabla weights and biases - the change of rate of each one of weights and biases on the network</returns>
-    public void Backpropagation(List<List<double>> activations, List<List<double>> zs, 
+    public GradientParameters Backpropagation(List<List<double>> activations, List<List<double>> zs, 
         List<double> prediction, List<double> target, double learningRate, BackpropagationMethod method = BackpropagationMethod.Forloop)
     {
         int intermittenLayer = NumLayers - 2;
@@ -564,9 +709,12 @@ public class Network : INetwork
             }
         }
         
-        // Update the weight and biases
-        UpdateWeights(nablaWeights, learningRate);
-        UpdateBiases(nablaBiases, learningRate);
+        GradientParameters gradientParameters = new()
+        {
+            NablaBiases = nablaBiases,
+            NablaWeights = nablaWeights
+        };
+        return gradientParameters;
     }
     
     
@@ -584,42 +732,23 @@ public class Network : INetwork
         for (int i = 1; i <= epochs; i++)
         {
             Console.WriteLine($"Epoch #{i}/{epochs}....");
-            
             // Get the shuffle version of dataset
-            List<(List<string>, List<double[]>)> batches =
+            List<BatchData> batches =
                 _datasetLoader.ShuffleDataset(dataset.TrainingDatasetImages, dataset.TrainingDatasetLabels, batchSize);
 
             // Processing the entire dataset but limit it by one batch at a time
             for (int j = 0; j < batches.Count; j++)
             {
                 Console.WriteLine($"Epoch #{i}/{epochs} | Batch {j + 1}/{batches.Count}....");
-                List<double> errorMiniBatch = new();
-                // Processing mini-batch
-                for (int k = 0; k < batches[j].Item1.Count; k++)
-                {
-                    // Item1 is the images
-                    // Item2 is the labels
-                    // Idk how I can change their name, please help me
-                    double[] imageProcessing = _imageProcessing.SingleImageProcessing(batches[j].Item1[k]);
-                    List<double> imageInput = imageProcessing.ToList();
-                    List<double> imageLabels = batches[j].Item2[k].ToList();
-                    List<double> prediction = UpdateMiniBatch(imageInput, imageLabels, learningRate, method);
-                    
-                    // TODO : Get the error between network result and the expected one-hot encoding result
-                    double error =
-                        CalculateMeanSquareErrorLoss(prediction, imageLabels);
-                    errorMiniBatch.Add(error);
-                }
-                double averageMiniBatchLoss = errorMiniBatch.Average();
+                
+                // Processing mini-batch or update mini-batch, whether it's the batch size is 1 or more than one
+                double averageMiniBatchLoss = UpdateMiniBatch(batches[j], learningRate, method);
+                
                 Console.WriteLine($"Mini Batch average loss is {averageMiniBatchLoss}");
             }
             
-            // TODO : Update the weight and Biases based on batches?
-            // StochasticGradientDescent(averageLoss);
-            
         }
     }
-    
     
     /// <summary>
     /// Inference Pipeline

--- a/NeuralNetworkCSharp/Domain/BatchData.cs
+++ b/NeuralNetworkCSharp/Domain/BatchData.cs
@@ -1,0 +1,7 @@
+namespace NeuralNetworkCSharp.Domain;
+
+public class BatchData
+{
+    public List<string> Images { get; set; }
+    public List<double[]> Labels { get; set; }
+}

--- a/NeuralNetworkCSharp/Domain/GradientParameters.cs
+++ b/NeuralNetworkCSharp/Domain/GradientParameters.cs
@@ -1,0 +1,7 @@
+namespace NeuralNetworkCSharp.Domain;
+
+public class GradientParameters
+{
+    public List<List<List<double>>> NablaWeights { get; set; }
+    public List<List<double>> NablaBiases { get; set; }
+}

--- a/NeuralNetworkCSharp/Interface/INetwork.cs
+++ b/NeuralNetworkCSharp/Interface/INetwork.cs
@@ -1,3 +1,4 @@
+using NeuralNetworkCSharp.Domain;
 using NeuralNetworkCSharp.Enum;
 
 namespace NeuralNetworkCSharp.Interface;
@@ -7,9 +8,9 @@ public interface INetwork
     void Train(string trainingFilePath, int epochs, int batchSize, double learningRate, BackpropagationMethod method);
     void Test();
     List<double> Fit(string filePath);
-    List<double> UpdateMiniBatch(List<double> dataInput, List<double> dataLabel, double learningRate, BackpropagationMethod method);
+    double UpdateMiniBatch(BatchData batchData, double learningRate, BackpropagationMethod method);
     List<double> ForwardPass(List<double> input, out List<List<double>> activations, out List<List<double>> zs);
-    void Backpropagation(List<List<double>> activations, List<List<double>> zs, List<double> dataPrediction, List<double> dataLabel, double learningRate, BackpropagationMethod method);
+    GradientParameters Backpropagation(List<List<double>> activations, List<List<double>> zs, List<double> dataPrediction, List<double> dataLabel, double learningRate, BackpropagationMethod method);
     void ImportWeights(List<double> importedWeights);
     void ImportBiases(List<double> importedBiases);
     List<double> ExportWeights();

--- a/NeuralNetworkCSharp/Program.cs
+++ b/NeuralNetworkCSharp/Program.cs
@@ -7,7 +7,7 @@ static class Program
     public static void Main(string[] args)
     {
         const int inputLayer = 784;
-        const int hiddenLayer = 15;
+        const int hiddenLayer = 20;
         const int outputLayer = 10;
         List<int> networkSize = new List<int>(){ inputLayer, hiddenLayer, outputLayer };
         
@@ -17,12 +17,18 @@ static class Program
         var trainingDirectory = "C:/Jun Local Things/Playground/Neural Network C#/mnist_png/train";
         
         // Start training process
-        network.Train(trainingDirectory, 10, 1000, 0.01);
+        // Batch size selection? Perhaps see this reference -> https://arxiv.org/abs/1206.5533 
+        network.Train(trainingDirectory, 10, 32, 0.1);
         
         // Save the model result
         network.SaveModel("./model.wes");
         
         // Test the network model
-
+        string testImage = "C:/Jun Local Things/Playground/Neural Network C#/mnist_png/valid/2/35.png";
+        List<double> prediction = network.Fit(testImage);
+        foreach (var p in prediction)
+        {
+            Console.WriteLine(p);
+        }
     }
 }


### PR DESCRIPTION
Implementing batch gradient descent for updating the weights and bias itself. Previously,  even thought that I have split the dataset into mini batches, which is for an example if the dataset is 100, and the batch size is 10, that means there will be 10 mini batches in every mini batches is 100, but as you can see in the [code](https://github.com/WallNutss/neural-network-csharp/blob/2b1b5952951645983b1c59909047ae33d7d8fe49/NeuralNetworkCSharp/Core/Network.cs#L606), even though I have split them into mini batches, I still input them one by one and immediately update the weights and bias. Making it not really correct as this prone to bias as every weight & bias update are dependent on each data sample.

So, I think rather than that, what if like for an example get the batch size set to like 5, the different is that rather update the parameters in every sample, we will get the $\nabla_{W}$ and $\nabla_{b}$, and average them based on the batch size and then we can update the weight and bias. So, it should be inline with the source that if the loss function is define like this

$\nabla_{L} \approx \frac{1}{n} \sum_{x} C_x$ 

Where this is tell us that the value of the loss gradient is equal to the sum of the average of the gradient of the parameters. We can extend them to this branch thingy, when updating the network parameters, we can average the each of the gradients $\nabla_{L}$ of the current gradients parameter of the data and by aggregate them first along the batch data that as you can see on the `AccumulatedGradients` function. Then average them when updating the weights and biases in this formula, which is in the end achieving the average of the loss function, WITH... achieve it in every weight and biases parameter after all the batch data has been processed

$W_{k}^{'} = W_{k} - \frac{eta}{m} \nabla{W_k}$ 

From the formula above, by this also do the same thing that we previously do, which is if we want to still input them one by one and immediately update the weight and biases without averaging them, we can make the batch size into `1`, so it will only average one single point data, as the batch will contain only one data, making it in the end the same as when we input them one by one when updating it.